### PR TITLE
build: Attempt at automatic coverage reports.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,19 @@ m4/ltsugar.m4
 m4/ltversion.m4
 m4/lt~obsolete.m4
 
+#Coverage files
+src/*.gcda
+src/*.gcno
+src/api/*.gcda
+src/api/*.gcno
+src/api/internal/*.gcda
+src/api/internal/*.gcno
+src/tests/*.gcda
+src/tests/*.gcno
+src/utils/*.gcda
+src/utils/*.gcno
+
+
 # Jekyll files
 Gemfile.lock
 _site/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ compiler:
   - clang
   - gcc
 before_install:
-  - sudo apt-get install g++ gfortran libtool pkg-config libfftw3-dev libboost-dev libcppunit-dev libz-dev libblas-dev
+  - sudo apt-get install g++ gfortran libtool pkg-config libfftw3-dev libboost-dev libcppunit-dev libz-dev libblas-dev lcov
 script:
   - ./reconf
   - ./configure
@@ -12,3 +12,5 @@ script:
   - make dist
   - ./make_src_dist.sh
   - ./make_bin_dist.sh
+after_success:
+  - ./config/rebuild-coverage.sh

--- a/HACKING.md
+++ b/HACKING.md
@@ -234,6 +234,35 @@ If `clang` is not found, try:
     $ scan-build --use-analyzer=$(which clang) ./configure
     $ scan-build --use-analyzer=$(which clang) make
 
+### Code Coverage
+
+Use the script `./config/rebuild-coverage.sh` to rebuild and project with
+coverage instrumentation. The script will recomile lobSTR, then will run
+`make check` once to generate basic coverage information (and coverage report).
+
+More coverage information can be accumulated by running **lobSTR** again, or
+one of the provided tests (see **Test Script** section below).
+
+After accumulating more coverage information, re-generate the coverage report
+by running `./config/gen-coverage-report.sh` .
+
+If the coverage report was generated successfully, the output will be:
+
+```sh
+...
+...
+Writing directory view page.
+Overall coverage rate:
+  lines......: 25.1% (3355 of 13353 lines)
+  functions..: 37.4% (1818 of 4865 functions)
+
+
+Initial coverage report: ./lobstr-cov/index.html
+
+To accumulate more coverage information, run 'lobstr' again,
+then, re-generate the coverage report by re-running ./config/gen-coverage-report.sh
+```
+
 ### Profiling
 
 #### Using GNU prof

--- a/Makefile.am
+++ b/Makefile.am
@@ -20,6 +20,8 @@ DATA_FILES = \
 
 EXTRA_DIST = reconf configure \
 	config/git-version-gen \
+	config/gen-coverage-report.sh \
+	config/rebuild-coverage.sh \
 	lobSTR.rb \
 	$(top_srcdir)/.version \
 	$(DATA_FILES)

--- a/config/gen-coverage-report.sh
+++ b/config/gen-coverage-report.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+##
+## A small helper script to re-generate coverage report.
+##
+
+die()
+{
+  BASE=$(basename "$0")
+  echo "$BASE error: $@" >&2
+  exit 1
+}
+
+cd $(dirname "$0")/.. || die "failed to set directory"
+
+GCDAFILES=$(find -name "*.gcda") || die "failed to search for *.gcda files"
+GCNOFILES=$(find -name "*.gcno") || die "failed to search for *.gcno files"
+[ -z "$GCDAFILES" -o -z "$GCNOFILES" ] && die "No coverage files found (*.gcda/*.gcno) - did you rebuild with coverage instrumentation? try ./build-aux/rebuild-coverage.sh"
+
+PROJECT=lobstr
+LCOVFILE="$PROJECT.lcov"
+REPORTDIR="$PROJECT-cov"
+
+rm -f  "./$LCOVFILE"
+rm -rf "./$REPORTDIR"
+
+## Then generate the coverage report
+lcov -t "$PROJECT" -q -d src -d src/tests -c -o "$LCOVFILE" || die "lcov failed"
+genhtml -t "$PROJECT" --output-directory "$REPORTDIR" "$LCOVFILE" || die "genhtml failed"
+
+echo
+echo
+echo "Initial coverage report: ./$REPORTDIR/index.html"
+echo ""
+echo "To accumulate more coverage information, run '$PROJECT' again,"
+echo "then, re-generate the coverage report by re-running $0"
+echo ""
+

--- a/config/rebuild-coverage.sh
+++ b/config/rebuild-coverage.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+##
+## A small helper script to rebuild the project with coverage instrumentation.
+##
+
+die()
+{
+  BASE=$(basename "$0")
+  echo "$BASE error: $@" >&2
+  exit 1
+}
+
+cd $(dirname "$0")/.. || die "failed to set directory"
+
+find "$PWD" \( -name "*.gcda" -o -name "*.gcno" \) -delete || die "deleting existing gcda/gcno files failed"
+
+COVFLAGS="-g -fprofile-arcs -ftest-coverage"
+./configure CFLAGS="$COVFLAGS" CXXFLAGS="$COVFLAGS" || die "./configure failed"
+make clean || die "make clean failed"
+make || die "make failed"
+
+## Automatically run the basic checks, at least once.
+make check || die "make check failed"
+
+## Generate the initial coverage report
+DIR=$(dirname "$0") || die "failed to detect script's directory"
+GEN="$DIR/gen-coverage-report.sh"
+[ -e "$GEN" ] || die "Required script '$GEN' not found"
+
+"$GEN" || die "failed to generate coverage report"


### PR DESCRIPTION
Added two scripts in './config' to ease coverage testing.

Runs coverage report at the end of successful Travis-CI build (only works for GCC, but doesn't signal failure  with CLANG).

Documented in 'HACKING.md'
