### PR TITLE
standardize read ids before printing bam file

### DIFF
--- a/src/SamFileWriter.h
+++ b/src/SamFileWriter.h
@@ -43,6 +43,7 @@ class SamFileWriter {
   void WriteRecord(const ReadPair& read_pair);
   virtual ~SamFileWriter();
  private:
+  std::string StandardizeReadID(const std::string& readid, bool paired);
   std::map<std::string, int> chrom_sizes;
   BamTools::BamWriter writer;
 };


### PR DESCRIPTION
In order to pass bam validation, read ids of mates must be the same. Added a function to:
- split read id on white space and take only the first item
- remove trailing /1 and /2 from paired end read ids
