### PR TITLE
adding PQ field

### DIFF
--- a/src/STRRecord.h
+++ b/src/STRRecord.h
@@ -44,6 +44,7 @@ struct STRRecord {
   vector<int> allele2;
   vector<int> coverage;
   vector<float> max_log_lik; // maximum likelihood
+  vector<float> phred_max_lik_score; // -log10(1-max_lik_score)
   vector<float> max_lik_score; // ML/sum of all likelihoods
   vector<float> allele1_marginal_lik_score; // marginal likelihood score
   vector<float> allele2_marginal_lik_score; // marginal likelihood score


### PR DESCRIPTION
Added "PQ" field that gives -log10(1-Q) with the hopes of giving higher resolution. Many Q scores for high coverage data currently get set to 1 because of a lack of precision.

One issue that came up is that for loci with only 1 allele, all Q scores were set to 1 regardless of coverage. This is since Q is defined as the likelihood of the max lik genotype over the sum of likelihoods for all tested genotypes. Previously, we only tested genotypes consisting of alleles that had been observed so this ratio was always 1. I added to also look at likelihoods for nearby genotypes within some range of observed alleles to account for stutter.