### PR TITLE
Fixed implementation of fexists.

### DIFF
--- a/src/common.cpp
+++ b/src/common.cpp
@@ -192,7 +192,7 @@ void TrimRead(const string& input_nucs,
 
 bool fexists(const char *filename) {
   ifstream ifile(filename);
-  return ifile;
+  return ifile.good();
 }
 
 bool valid_nucleotides_string(const string &str) {


### PR DESCRIPTION
g++ 6.2.0 (Ubuntu Yakkety) rejects the current implementation with the following message:

```
cannot convert 'std::ifstream {aka std::basic_ifstream<char>}' to 'bool' in return
```

An explicit call to the `good()` method of `ifstream` takes care of the problem.